### PR TITLE
Updating all dependencies. Pinning eslint to ~2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,20 +19,20 @@
     "url": "https://github.com/dcaballeroc/angular2-es6-playground/issues"
   },
   "homepage": "https://github.com/dcaballeroc/angular2-es6-playground#readme",
+  "dependencies": {
+    "babel-polyfill": "^6.7.2"
+  },
   "devDependencies": {
-    "babel-core": "^6.5.2",
+    "babel-core": "^6.7.2",
     "babel-eslint": "^5.0.0",
-    "babel-loader": "^6.2.3",
-    "babel-preset-es2015": "^6.5.0",
+    "babel-loader": "^6.2.4",
+    "babel-preset-es2015": "^6.6.0",
     "css-loader": "^0.23.1",
-    "eslint": "^2.2.0",
-    "eslint-config-airbnb": "^6.0.2",
+    "eslint": "~2.2.0",
+    "eslint-config-airbnb": "^6.1.0",
     "eslint-loader": "^1.3.0",
     "style-loader": "^0.13.0",
     "webpack": "^1.12.14",
     "webpack-dev-server": "^1.14.1"
-  },
-  "dependencies": {
-    "babel-polyfill": "^6.5.0"
   }
 }


### PR DESCRIPTION
Eslint 2.3.0+ is broken when asking for `estraverse-fb`. Pinning until solved (NOT soved @2.4.x)
